### PR TITLE
tweak style details after #35

### DIFF
--- a/src/styles/hightable.css
+++ b/src/styles/hightable.css
@@ -43,9 +43,9 @@
   --menu-inner-border-color: var(--gray-5);
   --row-number-hovered-right-border-color: var(--gray-5);
   --corner-cell-right-border-color: var(--gray-5);
-  --row-number-right-border-color : var(--gray-5);
+  --row-number-right-border-color: var(--gray-5);
+  --top-border-color: var(--gray-5);
 
-  --top-border-color: var(--gray-12);
   --focus-border-color: var(--gray-12);
   --focusable-border-color: var(--gray-12);
   --resizer-hovered-right-border-color: var(--gray-12);
@@ -57,7 +57,8 @@
   thead {
     th {
       border-bottom-width: 1px;
-      [role="spinbutton"]:focus, [role="spinbutton"]:hover {
+      [role="spinbutton"]:focus,
+      [role="spinbutton"]:hover {
         margin: 0;
       }
     }
@@ -75,6 +76,14 @@
     }
     [role="cell"] {
       font-family: var(--code-font-family);
+    }
+  }
+
+  /* fix bug in hightable CSS */
+  thead td:first-child,
+  tbody [role="rowheader"] {
+    &:focus {
+      background-color: var(--focus-background-color);
     }
   }
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -74,7 +74,7 @@ main {
   flex: 1;
   min-width: 0;
   color: var(--gray-12);
-  background: var(--gray-1);
+  background: var(--white);
 }
 
 #app {


### PR DESCRIPTION
- white default background (or black in dark mode)
- fix focused cell background in left column
- lighter border at the top of the table

Before:

<img width="1247" height="472" alt="Screenshot From 2026-01-07 11-08-10" src="https://github.com/user-attachments/assets/d0ce710a-dd52-4aff-987f-002ab1d062e2" />

After:

<img width="1247" height="472" alt="Screenshot From 2026-01-07 11-07-43" src="https://github.com/user-attachments/assets/6066cac0-aadb-48b8-a469-950846642c43" />

