### PR TITLE
More style details

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -13,6 +13,7 @@
     <meta name="author" content="Source.coop" />
     <meta name="keywords" content="csv, remote, table" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light dark" />
   </head>
   <body>
     <main id="content">

--- a/src/styles/colors.css
+++ b/src/styles/colors.css
@@ -16,13 +16,14 @@
   --gray-12: #202020;
 
   --gray-a11: #0000009b;
+
+  --accent-2: #ffffff;
 }
 @media (prefers-color-scheme: dark) {
   :root {
     --black: #ffffff;
+    --white: #000000;
     --gray-1: #111111;
-    /* In source.coop, white, in dark mode, is not black (#000000), but a very dark gray */
-    --white: var(--gray-1);
     --gray-2: #191919;
     --gray-3: #222222;
     --gray-4: #2a2a2a;
@@ -36,5 +37,7 @@
     --gray-12: #eeeeee;
 
     --gray-a11: #ffffffaf;
+
+    --accent-2: #191919;
   }
 }

--- a/src/styles/hightable.css
+++ b/src/styles/hightable.css
@@ -54,7 +54,8 @@
   --focus-border-width: 1px;
 
   /* other tweaks */
-  table * {
+  th,
+  td {
     font-family: var(--code-font-family);
   }
   thead {

--- a/src/styles/hightable.css
+++ b/src/styles/hightable.css
@@ -13,7 +13,7 @@
   --secondary-sort-icon-color: var(--gray-5);
 
   /* backgrounds */
-  --background-color: var(--white);
+  --background-color: unset;
   --menu-item-background-color: var(--white);
 
   --header-background-color: var(--gray-2);

--- a/src/styles/hightable.css
+++ b/src/styles/hightable.css
@@ -1,37 +1,37 @@
 /* Theme for hightable */
 .hightable {
   /* texts */
-  --header-color: var(--gray-12);
   --menu-color: var(--gray-12);
   --menu-item-color: var(--gray-12);
   --menu-button-color: var(--gray-12);
-  --text-color: var(--gray-12);
   --primary-sort-icon-color: inherit;
+  --header-color: var(--gray-12);
 
   --row-number-color: var(--gray-a11);
+  --text-color: var(--gray-a11);
 
   --secondary-sort-icon-color: var(--gray-5);
 
   /* backgrounds */
-  --background-color: unset;
-  --menu-item-background-color: var(--white);
+  --background-color: var(--accent-2);
+  --menu-item-background-color: var(--accent-2);
 
-  --header-background-color: var(--gray-2);
-  --focusable-background-color: var(--gray-2);
-  --menu-button-hovered-background-color: var(--gray-2);
-  --menu-button-focused-background-color: var(--gray-2);
-  --row-hovered-background-color: var(--gray-2);
+  --header-background-color: var(--gray-3);
+  --focusable-background-color: var(--gray-3);
+  --menu-button-hovered-background-color: var(--gray-3);
+  --menu-button-focused-background-color: var(--gray-3);
+  --row-hovered-background-color: var(--gray-3);
 
-  --menu-background-color: var(--gray-2);
-  --menu-button-background-color: var(--gray-2);
-  --menu-item-hovered-background-color: var(--gray-2);
-  --row-number-background-color: var(--gray-2);
-  --corner-cell-background-color: var(--gray-2);
-  --row-selected-background-color: var(--gray-2);
+  --menu-background-color: var(--gray-3);
+  --menu-button-background-color: var(--gray-3);
+  --menu-item-hovered-background-color: var(--gray-3);
+  --row-number-background-color: var(--gray-3);
+  --corner-cell-background-color: var(--gray-3);
+  --row-selected-background-color: var(--gray-3);
 
-  --focus-background-color: var(--gray-3);
-  --row-number-hovered-background-color: var(--gray-3);
-  --row-number-selected-background-color: var(--gray-3);
+  --focus-background-color: var(--gray-5);
+  --row-number-hovered-background-color: var(--gray-5);
+  --row-number-selected-background-color: var(--gray-5);
 
   --resize-indicator-background-color: var(--gray-12);
 
@@ -54,8 +54,12 @@
   --focus-border-width: 1px;
 
   /* other tweaks */
+  table * {
+    font-family: var(--code-font-family);
+  }
   thead {
     th {
+      font-weight: normal;
       border-bottom-width: 1px;
       [role="spinbutton"]:focus,
       [role="spinbutton"]:hover {
@@ -71,11 +75,6 @@
     [role="rowheader"] {
       text-align: right;
       padding-right: 0.5em;
-      font-size: 0.75em;
-      font-family: var(--code-font-family);
-    }
-    [role="cell"] {
-      font-family: var(--code-font-family);
     }
   }
 

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -74,7 +74,7 @@ main {
   flex: 1;
   min-width: 0;
   color: var(--gray-12);
-  background: var(--white);
+  background-color: var(--accent-2);
 }
 
 #app {


### PR DESCRIPTION
- use the same background as the box the iframe is inserted into, on source.coop (`--accent-2`)
- use monospace font for column headers
- invert colors between cells and column headers, to reduce the visual weight of the table
- change the column header font weight from bold (browser default) to normal
- make the special backgrounds (focused cells, header cells, etc) slightly more proeminent